### PR TITLE
Schoolbook multiplication for BigInt without reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Noir BigInt over arbitrary moduli

--- a/resources/parigp_scripts.md
+++ b/resources/parigp_scripts.md
@@ -1,0 +1,55 @@
+# PariGP scripts to support testing
+
+## Convert coefficient array to number
+Convert array into corresponding number.
+`[a0, a1, a2, a3]` equals `a0 + a1* 2^120 + a2 * 2^240 + a3 * 2^360`
+```
+array_to_number(limbs) = {
+    my(num = 0);
+    for (i = 1, #limbs,
+        num += limbs[i] * 2^((i-1) * 120);
+    );
+    num;
+}
+```
+
+If you have coefficient array `[1, 2, 3, 4]`, this equals the number `1+ 2*2^120 + 3*2^240 + 4*2^360`. 
+Print:
+```
+1+ 2*2^120 + 3*2^240 + 4*2^360
+```
+and seperately:
+```
+array_to_number([1, 2, 3, 4])
+```
+They should be equal. 
+
+Another example. The max size of coefficient is 120 bits. Max value is `2^120 -1` = `0xffffffffffffffffffffffffffffff`. The number represented by array of 4x the max coefficient is 
+```
+(2^120 -1)+ (2^120 -1)*2^120 + (2^120 -1)*2^240 + (2^120 -1)*2^360. 
+```
+Compare that with:
+```
+array_to_number([0xffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffff])
+```
+
+## Schoolbook
+
+Compare the multiplication in PariGP
+```
+a = array_to_number([0xffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffff]);
+b = array_to_number([0xffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffff]);
+a*b
+# = 3121748550315992231381597229793166305748598142664971150859156959625371735286071490563537443896896969673989899466438829144210059436075882721050625
+```
+...with the resulting limbs from the Noir function:
+```
+# 0xfffffffffffffffffffffffffffffe000000000000000000000000000001
+# 0x01fffffffffffffffffffffffffffffc000000000000000000000000000002
+# 0xfffffffffffffffffffffffffffffe000000000000000000000000000001
+    
+array_to_number([0xfffffffffffffffffffffffffffffe000000000000000000000000000001,0x01fffffffffffffffffffffffffffffc000000000000000000000000000002,0xfffffffffffffffffffffffffffffe000000000000000000000000000001])
+# = 3121748550315992231381597229793166305748598142664971150859156959625371735286071490563537443896896969673989899466438829144210059436075882721050625
+# Correct!
+```
+Note that the limbs of the result from Noir are not necessarily smaller than 120 bits. This is why converting the resulting number back to the coefficient array in PariGP won't give the same answer. 

--- a/src/bigint.nr
+++ b/src/bigint.nr
@@ -53,7 +53,7 @@ pub fn get_qc_add(a: BigInt, b: BigInt, p: BigInt) -> (Field, BigInt) {
     // Step 2. Try to subtract p, if possible
     // Initialize vector for the same length
     let mut reduced_limbs: Vec<Field> = Vec::new();
-    for i in 0..a.limbs.len() {
+    for _ in 0..a.limbs.len() {
         reduced_limbs.push(0);
     }
 
@@ -135,6 +135,38 @@ pub fn get_qc_add(a: BigInt, b: BigInt, p: BigInt) -> (Field, BigInt) {
     }
 }
 
+/*
+Returns multiplication a*b without any reduction on the limbs.
+If a and b have n limbs, the result will have 2n-1 limbs. 
+
+Performs standard schoolbook multiplication
+
+This will work fine for <= 16384 limbs in the bigint. Reasoning:
+
+Limb is 120 bits -> multiplication of 2 limbs is 240 bits
+Adding x limbs of 240 limbs takes 240 + log_2(x) bits
+Field has 254 bits
+Solve for x: 254 = 240 + log_2(x)
+x = 16384
+So 16384 additions of multiplied limbs are possible before reducing is needed
+*/
+pub fn schoolbook_mult_no_reduction(a: BigInt, b: BigInt) -> BigInt {
+    assert(a.limbs.len() == b.limbs.len());
+
+    let n = a.limbs.len();
+    let mut res_limbs = Vec::new();
+    for _ in 0..2 * n - 1 {
+        res_limbs.push(0);
+    }
+    for i in 0..n {
+        for j in 0..n {
+            res_limbs.slice[i+j] += a.limbs.get(i)*b.limbs.get(j);
+        }
+    }
+
+    BigInt { limbs: res_limbs }
+}
+
 // TODO place these helper functions in utils / somewhere
 
 // Returns the field cast to U128
@@ -172,7 +204,8 @@ fn test_get_qc_add_no_reduction() {
 
     let (q, c) = get_qc_add(a, b, p);
 
-    assert_equal(c.limbs, [6, 8, 10, 12].as_slice(), 4)
+    assert_equal(c.limbs, [6, 8, 10, 12].as_slice(), 4);
+    assert(q == 0);
 }
 
 /*
@@ -193,7 +226,8 @@ fn test_get_qc_add_with_reduction() {
 
     let (q, c) = get_qc_add(a, b, p);
 
-    assert_equal(c.limbs, [6, 8, 10, 3].as_slice(), 4)
+    assert_equal(c.limbs, [6, 8, 10, 3].as_slice(), 4);
+    assert(q == 1);
 }
 
 /*
@@ -219,7 +253,8 @@ fn test_get_qc_add_with_reduction_and_borrow() {
         c.limbs,
         [6, 8, 0xffffffffffffffffffffffffffffff, 2].as_slice(),
         4
-    )
+    );
+    assert(q == 1);
 }
 
 /*
@@ -260,7 +295,132 @@ fn test_get_qc_add_with_reduction_and_borrow2() {
         0xffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffff, 0xfffffffffffffffffffffffffffffe, 2
     ].as_slice(),
         4
-    )
+    );
+    assert(q == 1);
+}
+
+/*
+Function: schoolbook_mult_no_reduction
+
+Testcase: 
+- 4 small limbs
+- 2 limbs of 2^120-1
+- 30 limbs of 2^120-1
+*/
+#[test]
+fn test_schoolbook_mult() {
+    // Case 1: 4 small limbs
+    let a1 = BigInt::from_slice(&[1, 2, 3, 4]);
+    let b1 = BigInt::from_slice(&[5, 6, 7, 8]);
+    let c1 = schoolbook_mult_no_reduction(a1, b1);
+
+    assert_equal(c1.limbs, [5, 16, 34, 60, 61, 52, 32].as_slice(), 7);
+
+    // Case 2: 2 limbs of the max value
+    let a2 = BigInt::from_slice(&[0xffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffff]);
+    let b2 = BigInt::from_slice(&[0xffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffff]);
+    let c2 = schoolbook_mult_no_reduction(a2, b2);
+    // 2^120-1, 2^120-1
+    // 2^120-1 + 2^120-1 * 2^120 = 1766847064778384329583297500742918515827483896875618958121606201292619775
+
+    /*
+    Expected outcome:
+    3121748550315992231381597229793166305748598142664971150859156959625371735286071490563537443896896969673989899466438829144210059436075882721050625
+
+    If limbs are:
+    0xfffffffffffffffffffffffffffffe000000000000000000000000000001
+    0x01fffffffffffffffffffffffffffffc000000000000000000000000000002
+    0xfffffffffffffffffffffffffffffe000000000000000000000000000001
+    That sums up to:
+    1766847064778384329583297500742918513169027905305787212313992080731930625 + 3533694129556768659166595001485837026338055810611574424627984161463861250 * 2^120 + 1766847064778384329583297500742918513169027905305787212313992080731930625* 2^240
+    = 3121748550315992231381597229793166305748598142664971150859156959625371735286071490563537443896896969673989899466438829144210059436075882721050625
+    Correct
+    */
+    assert_equal(
+        c2.limbs,
+        [
+        0xfffffffffffffffffffffffffffffe000000000000000000000000000001, 0x01fffffffffffffffffffffffffffffc000000000000000000000000000002, 0xfffffffffffffffffffffffffffffe000000000000000000000000000001
+    ].as_slice(),
+        3
+    );
+
+    // Case 3: 30 limbs of the max value
+    let mut a3_limbs = Vec::new();
+    let mut b3_limbs = Vec::new();
+    for _ in 0..30 {
+        a3_limbs.push(0xffffffffffffffffffffffffffffff);
+        b3_limbs.push(0xffffffffffffffffffffffffffffff);
+    }
+    let a3 = BigInt { limbs: a3_limbs };
+    let b3 = BigInt { limbs: b3_limbs };
+    let c3 = schoolbook_mult_no_reduction(a3, b3);
+
+    assert_equal(
+        c3.limbs,
+        [
+        0xfffffffffffffffffffffffffffffe000000000000000000000000000001,
+        0x01fffffffffffffffffffffffffffffc000000000000000000000000000002,
+        0x02fffffffffffffffffffffffffffffa000000000000000000000000000003,
+        0x03fffffffffffffffffffffffffffff8000000000000000000000000000004,
+        0x04fffffffffffffffffffffffffffff6000000000000000000000000000005,
+        0x05fffffffffffffffffffffffffffff4000000000000000000000000000006,
+        0x06fffffffffffffffffffffffffffff2000000000000000000000000000007,
+        0x07fffffffffffffffffffffffffffff0000000000000000000000000000008,
+        0x08ffffffffffffffffffffffffffffee000000000000000000000000000009,
+        0x09ffffffffffffffffffffffffffffec00000000000000000000000000000a,
+        0x0affffffffffffffffffffffffffffea00000000000000000000000000000b,
+        0x0bffffffffffffffffffffffffffffe800000000000000000000000000000c,
+        0x0cffffffffffffffffffffffffffffe600000000000000000000000000000d,
+        0x0dffffffffffffffffffffffffffffe400000000000000000000000000000e,
+        0x0effffffffffffffffffffffffffffe200000000000000000000000000000f,
+        0x0fffffffffffffffffffffffffffffe0000000000000000000000000000010,
+        0x10ffffffffffffffffffffffffffffde000000000000000000000000000011,
+        0x11ffffffffffffffffffffffffffffdc000000000000000000000000000012,
+        0x12ffffffffffffffffffffffffffffda000000000000000000000000000013,
+        0x13ffffffffffffffffffffffffffffd8000000000000000000000000000014,
+        0x14ffffffffffffffffffffffffffffd6000000000000000000000000000015,
+        0x15ffffffffffffffffffffffffffffd4000000000000000000000000000016,
+        0x16ffffffffffffffffffffffffffffd2000000000000000000000000000017,
+        0x17ffffffffffffffffffffffffffffd0000000000000000000000000000018,
+        0x18ffffffffffffffffffffffffffffce000000000000000000000000000019,
+        0x19ffffffffffffffffffffffffffffcc00000000000000000000000000001a,
+        0x1affffffffffffffffffffffffffffca00000000000000000000000000001b,
+        0x1bffffffffffffffffffffffffffffc800000000000000000000000000001c,
+        0x1cffffffffffffffffffffffffffffc600000000000000000000000000001d,
+        0x1dffffffffffffffffffffffffffffc400000000000000000000000000001e,
+        0x1cffffffffffffffffffffffffffffc600000000000000000000000000001d,
+        0x1bffffffffffffffffffffffffffffc800000000000000000000000000001c,
+        0x1affffffffffffffffffffffffffffca00000000000000000000000000001b,
+        0x19ffffffffffffffffffffffffffffcc00000000000000000000000000001a,
+        0x18ffffffffffffffffffffffffffffce000000000000000000000000000019,
+        0x17ffffffffffffffffffffffffffffd0000000000000000000000000000018,
+        0x16ffffffffffffffffffffffffffffd2000000000000000000000000000017,
+        0x15ffffffffffffffffffffffffffffd4000000000000000000000000000016,
+        0x14ffffffffffffffffffffffffffffd6000000000000000000000000000015,
+        0x13ffffffffffffffffffffffffffffd8000000000000000000000000000014,
+        0x12ffffffffffffffffffffffffffffda000000000000000000000000000013,
+        0x11ffffffffffffffffffffffffffffdc000000000000000000000000000012,
+        0x10ffffffffffffffffffffffffffffde000000000000000000000000000011,
+        0x0fffffffffffffffffffffffffffffe0000000000000000000000000000010,
+        0x0effffffffffffffffffffffffffffe200000000000000000000000000000f,
+        0x0dffffffffffffffffffffffffffffe400000000000000000000000000000e,
+        0x0cffffffffffffffffffffffffffffe600000000000000000000000000000d,
+        0x0bffffffffffffffffffffffffffffe800000000000000000000000000000c,
+        0x0affffffffffffffffffffffffffffea00000000000000000000000000000b,
+        0x09ffffffffffffffffffffffffffffec00000000000000000000000000000a,
+        0x08ffffffffffffffffffffffffffffee000000000000000000000000000009,
+        0x07fffffffffffffffffffffffffffff0000000000000000000000000000008,
+        0x06fffffffffffffffffffffffffffff2000000000000000000000000000007,
+        0x05fffffffffffffffffffffffffffff4000000000000000000000000000006,
+        0x04fffffffffffffffffffffffffffff6000000000000000000000000000005,
+        0x03fffffffffffffffffffffffffffff8000000000000000000000000000004,
+        0x02fffffffffffffffffffffffffffffa000000000000000000000000000003,
+        0x01fffffffffffffffffffffffffffffc000000000000000000000000000002,
+        0xfffffffffffffffffffffffffffffe000000000000000000000000000001
+    ].as_slice(),
+        59
+    );
+    // TODO add more testcases
 }
 
 // Test helpers


### PR DESCRIPTION
This contains the (simple) schoolbook multiplication for BigInt without reducing limbs to 120 bits or reduction mod p.

We concluded that BigInt can have over 16k limbs and this algorithm won't overflow the resulting limbs. 

Added a few testcases, but can be extended. To check the correctness of the outcome, PariGP can be used. I added some scripts that I used to verify the tests for schoolbook mult in the folder `resources`. 